### PR TITLE
Add inference method to chi squared test and Change initialization method

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ $ pip uninstall sicore
 **その他の便利な機能**
 - OneVec：特定の場所が1，それ以外が0のベクトルを生成
 - polytope_to_interval()：二次形式の選択イベントを切断区間へと変換する関数
+- construct_projection_matrix()：基底からそれらが張る部分空間への射影行列を生成
 
 ## その他
 テストの実行：

--- a/sicore/__init__.py
+++ b/sicore/__init__.py
@@ -3,7 +3,7 @@ Core package for selective inference.
 """
 from . import intervals, utils
 from .intervals import polytope_to_interval
-from .utils import OneVec
+from .utils import OneVec, construct_projection_matrix
 from .cdf_mpmath import tc2_cdf_mpmath as tc2_cdf
 from .cdf_mpmath import tf_cdf_mpmath as tf_cdf
 from .cdf_mpmath import tn_cdf_mpmath as tn_cdf
@@ -72,5 +72,6 @@ __all__ = [
     "intervals",
     "utils",
     "polytope_to_interval",
+    "construct_projection_matrix",
     "OneVec"
 ]

--- a/sicore/inference/chi_squared.py
+++ b/sicore/inference/chi_squared.py
@@ -437,5 +437,100 @@ class SelectiveInferenceChiSquared(InferenceChiSquared):
             return random.choice(args)
         return max(args, key=method)
 
-    def inference():
-        pass
+    def inference(
+        self,
+        algorithm: Callable[[np.ndarray, np.ndarray, float], Tuple[List[List[float]], Any]],
+        model_selector: Callable[[Any], bool],
+        significance_level: float = 0.05,
+        tail: str = 'right',
+        tol: float = 1e-10,
+        step: float = 1e-10,
+        check_only_reject_or_not: bool = False,
+        over_conditioning: bool = False,
+        line_search: bool = True,
+        max_tail: float = 1e3,
+        choose_method: str = 'high_pdf',
+        retain_selected_model: bool = False,
+        retain_mappings: bool = False,
+        dps: int | str = 'auto',
+        max_dps: int = 5000,
+        out_log: str = 'test_log.log'
+    ) -> Type[SelectiveInferenceResult]:
+        """Perform Selective Inference. This is unified interface for SI.
+
+        Args:
+            algorithm (Callable[[np.ndarray, np.ndarray, float], Tuple[List[List[float]], Any]]):
+                Callable function which takes two vectors (`a`, `b`)
+                and a scalar `z` that can satisfy `data = a + b * z`
+                as arguments, and returns the selected model (any) and
+                the truncation intervals (array-like). A closure function might be
+                helpful to implement this.
+            model_selector (Callable[[Any], bool]):
+                Callable function which takes a selected model (any) as single argument, and
+                returns True if the model is used for the testing, and False otherwise.
+            significance_level (float, optional):
+                Significance level for the testing. Defaults to 0.05.
+            tail (str, optional):
+                'double' for double-tailed test, 'right' for right-tailed test, and
+                'left' for left-tailed test. Defaults to 'double'.
+            tol (float, optional):
+                Tolerance error parameter. Defaults to 1e-10.
+            step (float, optional):
+                Step width for line search. Defaults to 1e-10.
+            check_only_reject_or_not (bool, optional):
+                Inference only for rejectness. Defaults to False.
+            over_conditioning (bool, optional):
+                Over conditioning Inference. Defaults to False.
+            line_search (bool, optional):
+                Wheter to perform a line search or a random search. Defaults to True.
+            max_tail (float, optional):
+                Maximum tail value to be parametrically searched when neither option
+                check_only_rejecto_or_not nor over_coditionig is enabled. Defaults to 1e3.
+            choose_method (str, optional):
+                When check_only_reject_or_not is activated, 'near_stat' and 'high_pdf'
+                can be specified in the algorithm to select the search
+                direction. Defaults to 'near_stat'.
+            retain_selected_model (bool, optional):
+                Whether retain selected model as returns or not. Defaults to False.
+            retain_mappings (bool, optional):
+                Whether retain mappings as returns or not. Defaults to False.
+            dps (int | str, optional):
+                dps value for mpmath. Set 'auto' to select dps
+                automatically. Defaults to 'auto'.
+            max_dps (int, optional):
+                Maximum dps value for mpmath. This option is valid
+                when `dps` is set to 'auto'. Defaults to 5000.
+            out_log (str, optional):
+                Name for log file of mpmath. Defaults to 'test_log.log'.
+        Raises:
+            Exception:
+                The two options, check_only_reject_or_not and over-conditioning,
+                cannot be activated at the same time.
+
+        Returns:
+            Type[SelectiveInferenceResult]
+        """
+
+        if over_conditioning and check_only_reject_or_not:
+            raise Exception(
+                'The two options, check_only_reject_or_not and over-conditioning, cannot be activated at the same time.'
+            )
+
+        if over_conditioning:
+            result = self._over_conditioned_inference(
+                algorithm, significance_level, tail, retain_selected_model,
+                tol, dps, max_dps, out_log)
+            return result
+
+        elif check_only_reject_or_not:
+            result = self._rejectability_only_inference(
+                algorithm, model_selector, significance_level, tail, choose_method,
+                retain_selected_model, retain_mappings, tol, step,
+                dps, max_dps, out_log)
+
+        else:
+            result = self._parametric_inference(
+                algorithm, model_selector, significance_level, tail, line_search, max_tail,
+                retain_selected_model, retain_mappings, tol, step, dps, max_dps, out_log)
+
+        return result

--- a/sicore/utils.py
+++ b/sicore/utils.py
@@ -42,3 +42,13 @@ class OneVec:
             vec[i - 1: j] = 1
 
         return vec
+
+
+def construct_projection_matrix(basis):
+    basis = np.array(basis)
+    V = np.linalg.qr(basis.T)[0]
+    P = np.dot(V, V.T)
+    if np.sum(np.abs(np.dot(P, P) - P)) > 1e-5 or np.sum(np.abs(P.T - P)) > 1e-5:
+        raise Exception(
+            "The projection matrix is not constructed correctly")
+    return P


### PR DESCRIPTION
I implemented the inference method in chi-square test.
- As described in Issue 8, the lower bound of truncated intervals is arbitrary.
- I have not verified that the method works.

The projection matrix is now received at initialization instead of the basis. The algorithm for constructing the projection matrix from the basis was cut out as a separate function.