### PR TITLE
fix: Cast var to float before calculating standard deviation

### DIFF
--- a/sicore/inference/base.py
+++ b/sicore/inference/base.py
@@ -148,5 +148,5 @@ def standardize(x, mean=0, var=1):
         mean (float, optional): Mean. Defaults to 0.
         var (float, optional): Variance. Defaults to 1.
     """
-    sd = np.sqrt(var)
+    sd = np.sqrt(float(var))
     return (np.asarray(x) - mean) / sd


### PR DESCRIPTION
## Description
This pull request ensures that the `standardize` function always returns a float output. Previously, if the input `var` was not a float, the function might return a non-float output, potentially leading to unexpected behavior in downstream code.

## Changes
Cast `var` to float using `float()` before calculating the standard deviation in the `standardize` function.